### PR TITLE
Adds Update Functionality to the IMAP Client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_CURRENT_S
 find_package(Qt5 REQUIRED NO_MODULE COMPONENTS Qml Quick)
 find_package(KF5 5.2 REQUIRED COMPONENTS Plasma I18n Declarative)
 find_package(KF5 REQUIRED COMPONENTS IMAP Mime KIO)
+find_package(KF5Config REQUIRED)
 
 include(FeatureSummary)
 include(KDEInstallDirs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(kdenow
     emailselectjob.cpp
     emailsessionjob.cpp
     singletonfactory.cpp
+    emailupdatejob.cpp
 )
 
 target_link_libraries(kdenow
@@ -13,6 +14,7 @@ target_link_libraries(kdenow
     KF5::IMAP
     KF5::KIOCore
     KF5::CoreAddons
+    KF5::ConfigCore
 )
 
 install(TARGETS kdenow ${INSTALL_TARGETS_DEFAULT_ARGS})

--- a/src/emailfetchjob.h
+++ b/src/emailfetchjob.h
@@ -21,6 +21,7 @@
 #define EMAILFETCHJOB_H
 
 #include <KIMAP/FetchJob>
+#include <KIMAP/Session>
 
 class EmailFetchJob : public QObject
 {
@@ -28,6 +29,7 @@ class EmailFetchJob : public QObject
 
     public:
         explicit EmailFetchJob(QObject* parent = 0);
+        void done(KIMAP::Session*);
 
     Q_SIGNALS:
         void fetchedEmail(KIMAP::MessagePtr email);
@@ -37,6 +39,8 @@ class EmailFetchJob : public QObject
         void slotMessagesReceived(const QString &mailBox, const QMap<qint64, qint64> &uids,
                               const QMap<qint64, KIMAP::MessagePtr> &messages);
 
+    private:
+        KIMAP::FetchJob* fetchJob;
 };
 
 #endif  //EMAILFETCHJOB_H

--- a/src/emailsearchjob.h
+++ b/src/emailsearchjob.h
@@ -27,9 +27,9 @@
 class EmailSearchJob : public QObject
 {
         Q_OBJECT
-
     public:
         explicit EmailSearchJob(QObject* parent = 0);
+        bool firstRun();
 
     public Q_SLOTS:
         void selectJobFinished(KJob*);

--- a/src/emailselectjob.cpp
+++ b/src/emailselectjob.cpp
@@ -36,6 +36,10 @@ void EmailSelectJob::loginJobFinished(KJob* job)
         qDebug() << loginJob->errorString();
         return;
     }
+    else {
+         qDebug() << "Login Job Done ";
+    }
+    loginJob->kill();
 
     KIMAP::SelectJob* selectJob = new KIMAP::SelectJob(
         SingletonFactory::instanceFor<EmailSessionJob>()->currentSession());

--- a/src/emailsessionjob.h
+++ b/src/emailsessionjob.h
@@ -35,6 +35,7 @@ class EmailSessionJob : public QObject
         void setPassword(const QString&);
         void setPort(qint16);
         void initiate();
+        void close();
 
         QString getUserName() const;
         QString getPassword() const;

--- a/src/emailupdatejob.cpp
+++ b/src/emailupdatejob.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 Aditya Dev Sharma <aditya.sharma15696@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "emailupdatejob.h"
+#include "singletonfactory.h"
+
+EmailUpdateJob::EmailUpdateJob(QObject* parent)
+    : QObject(parent)
+{
+
+}
+
+void EmailUpdateJob::update(KIMAP::IdleJob *job, const QString &mailBox,
+                            int messageCount, int recentCount)
+{
+    qDebug() << "Update !";
+    Q_UNUSED(mailBox)
+    Q_UNUSED(messageCount)
+    Q_UNUSED(recentCount)
+
+    job->stop();
+    SingletonFactory::instanceFor<EmailSessionJob>()->close();
+    updatesReceived();
+}
+
+void EmailUpdateJob::updatesReceived()
+{
+    SingletonFactory::instanceFor<EmailSessionJob>()->initiate();
+    qDebug() << SingletonFactory::instanceFor<EmailSessionJob>()->currentSession() << "\n";
+
+    KIMAP::LoginJob *loginJob = new KIMAP::LoginJob(SingletonFactory::instanceFor<EmailSessionJob>()->currentSession());
+    loginJob->setUserName(SingletonFactory::instanceFor<EmailSessionJob>()->getUserName());
+    loginJob->setPassword(SingletonFactory::instanceFor<EmailSessionJob>()->getPassword());
+    loginJob->setEncryptionMode(KIMAP::LoginJob::AnySslVersion);
+
+    EmailSelectJob *wrapperSelectJob = new EmailSelectJob();
+
+    QObject::connect(loginJob, &KJob::result, wrapperSelectJob, &EmailSelectJob::loginJobFinished);
+    loginJob->start();
+}

--- a/src/emailupdatejob.h
+++ b/src/emailupdatejob.h
@@ -17,55 +17,27 @@
  *
  */
 
+#ifndef EMAILUPDATEJOB_H
+#define EMAILUPDATEJOB_H
+
 #include "emailsessionjob.h"
+#include "emailselectjob.h"
 
-EmailSessionJob::EmailSessionJob(QObject* parent): QObject(parent)
-{
+#include <QtCore/QObject>
+#include <QtCore/QString>
 
-}
+#include <KIMAP/IdleJob>
+#include <KIMAP/LoginJob>
 
-void EmailSessionJob::initiate()
-{
-    m_session = new KIMAP::Session(m_hostName, m_port, this);
-}
+class EmailUpdateJob : public QObject {
+        Q_OBJECT
+    public:
+        explicit EmailUpdateJob(QObject* parent = 0);
+        void updatesReceived();
 
-void EmailSessionJob::setHostName(const QString& hostName)
-{
-    m_hostName = hostName;
-}
+    public Q_SLOTS:
+        void update(KIMAP::IdleJob *job, const QString &mailBox, int messageCount, int recentCount);
 
-void EmailSessionJob::setUserName(const QString& userName)
-{
-    m_userName = userName;
-}
+};
 
-void EmailSessionJob::setPassword(const QString& password)
-{
-    m_password = password;
-}
-
-void EmailSessionJob::setPort(qint16 port)
-{
-    m_port = port;
-}
-
-KIMAP::Session* EmailSessionJob::currentSession()
-{
-    return m_session;
-}
-
-QString EmailSessionJob::getPassword() const
-{
-    return m_password;
-}
-
-QString EmailSessionJob::getUserName() const
-{
-    return m_userName;
-}
-
-void EmailSessionJob::close()
-{
-    m_session->close();
-}
-
+#endif // EMAILUPDATEJOB_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,9 @@
 
 #include <KIMAP/Session>
 #include <KIMAP/LoginJob>
+#include <KConfigCore/KConfig>
+#include <KConfigCore/KConfigGroup>
+#include <KConfigCore/KSharedConfig>
 
 #include "emailsessionjob.h"
 #include "singletonfactory.h"
@@ -47,6 +50,11 @@ int main(int argc, char** argv)
         parser.showHelp(1);
     }
 
+    KSharedConfigPtr config = KSharedConfig::openConfig("kdenowrc");
+    KConfigGroup generalGroup(config, "General");
+    generalGroup.writeEntry("UIDNEXT", "FooBar");
+    generalGroup.config()->sync();
+
     EmailSessionJob* wrapperSessionJob = SingletonFactory::instanceFor<EmailSessionJob>();
     wrapperSessionJob->setHostName(parser.value("imapServer"));
     wrapperSessionJob->setUserName(parser.value("username"));
@@ -60,7 +68,6 @@ int main(int argc, char** argv)
     KIMAP::LoginJob* loginJob = new KIMAP::LoginJob(wrapperSessionJob->currentSession());
     loginJob->setUserName(wrapperSessionJob->getUserName());
     loginJob->setPassword(wrapperSessionJob->getPassword());
-    loginJob->setAuthenticationMode(KIMAP::LoginJob::Login);
     loginJob->setEncryptionMode(KIMAP::LoginJob::AnySslVersion);
 
     EmailSelectJob *wrapperSelectJob = new EmailSelectJob();


### PR DESCRIPTION
Uses the IDLE feature (check IMAP RFC), to go into an IDLE state
after fetching few emails. On receiving a signal that the mailbox
folder has changed, it updates the cache by again fetching all the emails.

Note here, that although the Updates work as expected, this solution is
not my final solution.

I intend to fetch ONLY the new emails, not the whole mailbox folder since
that consumes resources. I'm finding a solution that is not so "hackey".

Builds fine and tested with a test gmail id. Had to enable "Login from insecure apps"
feature for the gmail account, in order to test it, since GMail policies recognize
the client as using obsolete security. Will find a way out for that too, but
that will be probably near the end.
