### PR TITLE
Adds to the Update Functionality provided earlier.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,9 +52,12 @@ int main(int argc, char** argv)
 
     KSharedConfigPtr config = KSharedConfig::openConfig("kdenowrc");
     KConfigGroup generalGroup(config, "General");
-    generalGroup.writeEntry("UIDNEXT", "FooBar");
-    generalGroup.config()->sync();
-
+    QString state = generalGroup.readEntry("STATE", QString());
+    if (state != "Update") {
+        qDebug() << "FirstRun";
+        generalGroup.writeEntry("STATE", "FirstRun");
+        generalGroup.config()->sync();
+    }
     EmailSessionJob* wrapperSessionJob = SingletonFactory::instanceFor<EmailSessionJob>();
     wrapperSessionJob->setHostName(parser.value("imapServer"));
     wrapperSessionJob->setUserName(parser.value("username"));


### PR DESCRIPTION
 Only new emails will be fetched as they arrive.

Uses the ~/.config/kdenowrc to save the state information of the client
STATE can be "FirstRun" or "Update". Whenever the app is run for the first
time ever, the client saves the STATE as "FirstRun" in the ~/.config/kdenowrc

Then, it will fetch emails for the past month and make the STATE "Update".
Now whenever the client runs again OR any new mails are seen (IDLE), that
will be a part of "Update" state. The UIDNEXT is the server reply for the
next UID and that will be the one we download.

Future Improvements: I've seen during testing that whenever the user deletes
any email, the last email (which is already fetched) is fetched again. I need
to find a way around it.

Builds fine. Tested and works as expected using gmail.
