### PR TITLE
Do not fetch emails, when user deletes an email on the server

### DIFF
--- a/src/emailsearchjob.cpp
+++ b/src/emailsearchjob.cpp
@@ -63,12 +63,13 @@ void EmailSearchJob::selectJobFinished(KJob* job)
     if (firstRun()) {
         qDebug() << "First Run";
         qint64 nextUid = selectJob->nextUid();  //This will be the next UID of future EmailFetchJob
-        selectJob->kill();
         KSharedConfigPtr config = KSharedConfig::openConfig("kdenowrc");
         KConfigGroup generalGroup(config, "General");
         generalGroup.writeEntry("STATE", "Update");
         generalGroup.writeEntry("UIDNEXT", QString::number(nextUid));
+        generalGroup.writeEntry("MESSAGE_COUNT", QString::number(selectJob->messageCount()));
         generalGroup.config()->sync();
+        selectJob->kill();
 
         KIMAP::Term term(KIMAP::Term::Since, QDate::currentDate().addMonths(-1));
         KIMAP::SearchJob* searchJob = new KIMAP::SearchJob(SingletonFactory::instanceFor<EmailSessionJob>()->currentSession());
@@ -84,9 +85,10 @@ void EmailSearchJob::selectJobFinished(KJob* job)
         QString uidName = generalGroup.readEntry("UIDNEXT", QString());
         qint64 uidNext = uidName.toULongLong();
         qint64 uidToBeSaved = selectJob->nextUid();
-        selectJob->kill();
         generalGroup.writeEntry("UIDNEXT", QString::number(uidToBeSaved));
+        generalGroup.writeEntry("MESSAGE_COUNT", QString::number(selectJob->messageCount()));
         generalGroup.config()->sync();
+        selectJob->kill();
 
         KIMAP::ImapInterval interval;
         interval.setBegin(uidNext);


### PR DESCRIPTION
When the user deletes some emails on his end, we have an update signal from IDLE.
But we don't download new emails as it is not needed.

Whenever the client is run, it FETCHES one email, and that starts it event loop
of selecting/searching/fetching/updating. Even if there are no new emails in the
mailbox, the client will fetch the last received email to start the sort of event cycle.
If the mailBox is empty, the client exits.

Thing I need to do, is to see what would be a graceful way to do the even loop thing,
or merely notify the user that there are no emails in the mailBox, hence exiting.

Builds fine. Tested with gmail.
