### PR TITLE
Expose signal from daemon over D-Bus for Flight Extractor Plugin

### DIFF
--- a/qml/CMakeLists.txt
+++ b/qml/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (qml_plugins_SRCS
     qmlextensionsplugin.cpp
+    datahandler.cpp
     eventreservation.cpp
     flightreservation.cpp
     hotelreservation.cpp

--- a/qml/datahandler.cpp
+++ b/qml/datahandler.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2016  Aditya Dev Sharma <aditya.sharma156696@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "datahandler.h"
+
+#include <QtCore/QDebug>
+#include <QtDBus/QDBusReply>
+#include <QtDBus/QDBusInterface>
+#include <QtDBus/QDBusConnection>
+
+DataHandler::DataHandler(QObject* parent): QObject(parent)
+{
+    QDBusConnection dbus = QDBusConnection::sessionBus();
+    QDBusInterface* interface = new QDBusInterface("org.kde.kdenow", "/KDENow");
+
+    dbus.connect("org.kde.kdenow", "/Event", "org.kde.kdenow.event",
+                 "update", this, SLOT(onEventMapReceived()));
+    dbus.connect("org.kde.kdenow", "/Flight", "org.kde.kdenow.flight",
+                 "update", this, SLOT(onFlightMapReceived()));
+    dbus.connect("org.kde.kdenow", "/Hotel", "org.kde.kdenow.hotel",
+                 "update", this, SLOT(onHotelMapReceived()));
+    dbus.connect("org.kde.kdenow", "/Restaurant", "org.kde.kdenow.restaurant",
+                 "update", this, SLOT(onRestaurantMapReceived()));
+
+    //Call a method, to start the kdenowd daemon if it hasn't yet started
+    QDBusReply<QString> reply = interface->call("startDaemon");
+    if (reply.isValid()) {
+        qDebug() << "Valid Reply received from org.kde.kdenow /KDENow";
+        qDebug() << reply.value();
+    }
+    else {
+        qDebug() << "Did not receive a valid reply from org.kde.kdenow /KDENow";
+        return;
+    }
+}
+
+void DataHandler::onEventMapReceived()
+{
+    QDBusInterface* interface = new QDBusInterface("org.kde.kdenow", "/Event");
+    QDBusReply<QVariantMap> reply = interface->call("getMap");
+    if (reply.isValid()) {
+        qDebug() << "Valid Reply received from org.kde.kdenow /Event getMap";
+        qDebug() << reply.value();
+    }
+    else {
+        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Event getMap";
+        return;
+    }
+
+    emit eventDataReceived();
+}
+
+void DataHandler::onFlightMapReceived()
+{
+    QDBusInterface* interface = new QDBusInterface("org.kde.kdenow", "/Flight");
+    QDBusReply<QVariantMap> reply = interface->call("getMap");
+    if (reply.isValid()) {
+        qDebug() << "Valid Reply received from org.kde.kdenow /Flight getMap";
+        qDebug() << reply.value();
+    }
+    else {
+        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Flight getMap";
+        return;
+    }
+
+    emit flightDataReceived();
+}
+
+void DataHandler::onHotelMapReceived()
+{
+    QDBusInterface* interface = new QDBusInterface("org.kde.kdenow", "/Hotel");
+    QDBusReply<QVariantMap> reply = interface->call("getMap");
+    if (reply.isValid()) {
+        qDebug() << "Valid Reply received from org.kde.kdenow /Hotel getMap";
+        qDebug() << reply.value();
+    }
+    else {
+        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Hotel getMap";
+        return;
+    }
+
+    emit hotelDataReceived();
+}
+
+void DataHandler::onRestaurantMapReceived()
+{
+    QDBusInterface* interface = new QDBusInterface("org.kde.kdenow", "/Restaurant");
+    QDBusReply<QVariantMap> reply = interface->call("getMap");
+    if (reply.isValid()) {
+        qDebug() << "Valid Reply received from org.kde.kdenow /Restaurant getMap";
+        qDebug() << reply.value();
+    }
+    else {
+        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Restaurant getMap";
+        return;
+    }
+
+    emit restaurantDataReceived();
+}

--- a/qml/datahandler.h
+++ b/qml/datahandler.h
@@ -17,27 +17,31 @@
  *
  */
 
-#include "qmlextensionsplugin.h"
+#ifndef DATAHANDLER_H
+#define DATAHANDLER_H
 
-#include "datahandler.h"
-#include "eventreservation.h"
-#include "flightreservation.h"
-#include "hotelreservation.h"
-#include "restaurantreservation.h"
+#include <QtCore/QVariantMap>
 
-#include <QtQml/qqml.h>
-
-void QmlExtensionsPlugin::initializeEngine(QQmlEngine *engine, const char *uri)
+class DataHandler : public QObject
 {
+        Q_OBJECT
 
-}
+    public:
+        explicit DataHandler(QObject* parent = 0);
 
-void QmlExtensionsPlugin::registerTypes(const char *uri)
-{
-    qmlRegisterType<DataHandler>(uri, 0, 1, "DataHandler");
-    qmlRegisterType<EventReservation>(uri, 0, 1, "EventReservation");
-    qmlRegisterType<FlightReservation>(uri, 0, 1, "FlightReservation");
-    qmlRegisterType<HotelReservation>(uri, 0, 1, "HotelReservation");
-    qmlRegisterType<RestaurantReservation>(uri, 0, 1, "RestaurantReservation");
-}
+    Q_SIGNALS:
+        //These signals will be seen by Plasmoid's signal handler
+        void eventDataReceived();
+        void flightDataReceived();
+        void hotelDataReceived();
+        void restaurantDataReceived();
 
+    public Q_SLOTS:
+        void onEventMapReceived();
+        void onFlightMapReceived();
+        void onHotelMapReceived();
+        void onRestaurantMapReceived();
+};
+
+
+#endif //DATAHANDLER_H

--- a/qml/flightreservation.cpp
+++ b/qml/flightreservation.cpp
@@ -27,9 +27,14 @@
 FlightReservation::FlightReservation(QObject* parent): QObject(parent)
 {
     QDBusConnection dbus = QDBusConnection::sessionBus();
-    QDBusInterface* interface = new QDBusInterface("org.kde.kdenow", "/Flight");
+    m_interface = new QDBusInterface("org.kde.kdenow", "/Flight");
+    dbus.connect("org.kde.kdenow", "/Flight", "org.kde.kdenow.flight",
+                 "update", this, SLOT(onMapReceived()));
+}
 
-    QDBusReply<QVariantMap> reply = interface->call("getMap");
+void FlightReservation::onMapReceived()
+{
+    QDBusReply<QVariantMap> reply = m_interface->call("getMap");
     if (reply.isValid()) {
         qDebug() << "Valid Reply received from org.kde.kdenow /Flight";
         qDebug() << reply.value();
@@ -38,7 +43,6 @@ FlightReservation::FlightReservation(QObject* parent): QObject(parent)
         qDebug() << "Did not receive a valid reply from org.kde.kdenow /Flight";
         return;
     }
-
     m_map = reply.value();
 }
 

--- a/qml/flightreservation.cpp
+++ b/qml/flightreservation.cpp
@@ -30,10 +30,8 @@ FlightReservation::FlightReservation(QObject* parent): QObject(parent)
     m_interface = new QDBusInterface("org.kde.kdenow", "/Flight");
     dbus.connect("org.kde.kdenow", "/Flight", "org.kde.kdenow.flight",
                  "update", this, SLOT(onMapReceived()));
-}
 
-void FlightReservation::onMapReceived()
-{
+    //Call a method, to start the kdenwod daemon
     QDBusReply<QVariantMap> reply = m_interface->call("getMap");
     if (reply.isValid()) {
         qDebug() << "Valid Reply received from org.kde.kdenow /Flight";
@@ -43,6 +41,23 @@ void FlightReservation::onMapReceived()
         qDebug() << "Did not receive a valid reply from org.kde.kdenow /Flight";
         return;
     }
+
+    m_map = reply.value();
+}
+
+void FlightReservation::onMapReceived()
+{
+    //Get the new data
+    QDBusReply<QVariantMap> reply = m_interface->call("getMap");
+    if (reply.isValid()) {
+        qDebug() << "Valid Reply received from org.kde.kdenow /Flight";
+        qDebug() << reply.value();
+    }
+    else {
+        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Flight";
+        return;
+    }
+
     m_map = reply.value();
 }
 

--- a/qml/flightreservation.cpp
+++ b/qml/flightreservation.cpp
@@ -26,39 +26,7 @@
 
 FlightReservation::FlightReservation(QObject* parent): QObject(parent)
 {
-    QDBusConnection dbus = QDBusConnection::sessionBus();
-    m_interface = new QDBusInterface("org.kde.kdenow", "/Flight");
-    dbus.connect("org.kde.kdenow", "/Flight", "org.kde.kdenow.flight",
-                 "update", this, SLOT(onMapReceived()));
 
-    //Call a method, to start the kdenwod daemon
-    QDBusReply<QVariantMap> reply = m_interface->call("getMap");
-    if (reply.isValid()) {
-        qDebug() << "Valid Reply received from org.kde.kdenow /Flight";
-        qDebug() << reply.value();
-    }
-    else {
-        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Flight";
-        return;
-    }
-
-    m_map = reply.value();
-}
-
-void FlightReservation::onMapReceived()
-{
-    //Get the new data
-    QDBusReply<QVariantMap> reply = m_interface->call("getMap");
-    if (reply.isValid()) {
-        qDebug() << "Valid Reply received from org.kde.kdenow /Flight";
-        qDebug() << reply.value();
-    }
-    else {
-        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Flight";
-        return;
-    }
-
-    m_map = reply.value();
 }
 
 QString FlightReservation::reservationNumber() const

--- a/qml/flightreservation.h
+++ b/qml/flightreservation.h
@@ -24,7 +24,6 @@
 #include <QtCore/QString>
 #include <QtCore/QDateTime>
 #include <QtCore/QVariantMap>
-#include <QtDBus/QDBusReply>
 #include <QtDBus/QDBusInterface>
 
 class FlightReservation : public QObject

--- a/qml/flightreservation.h
+++ b/qml/flightreservation.h
@@ -24,6 +24,8 @@
 #include <QtCore/QString>
 #include <QtCore/QDateTime>
 #include <QtCore/QVariantMap>
+#include <QtDBus/QDBusReply>
+#include <QtDBus/QDBusInterface>
 
 class FlightReservation : public QObject
 {
@@ -50,8 +52,12 @@ class FlightReservation : public QObject
         QString arrivalAirportCode() const;
         QDateTime arrivalTime() const;
 
+    public Q_SLOTS:
+        void onMapReceived();
+
     private:
         QVariantMap m_map;
+        QDBusInterface* m_interface;
 };
 
 #endif //FLIGHTRESERVATION_H

--- a/qml/flightreservation.h
+++ b/qml/flightreservation.h
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *0
+ *
  */
 
 #ifndef FLIGHTRESERVATION_H

--- a/qml/flightreservation.h
+++ b/qml/flightreservation.h
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
+ *0
  */
 
 #ifndef FLIGHTRESERVATION_H
@@ -24,7 +24,6 @@
 #include <QtCore/QString>
 #include <QtCore/QDateTime>
 #include <QtCore/QVariantMap>
-#include <QtDBus/QDBusInterface>
 
 class FlightReservation : public QObject
 {
@@ -51,12 +50,8 @@ class FlightReservation : public QObject
         QString arrivalAirportCode() const;
         QDateTime arrivalTime() const;
 
-    public Q_SLOTS:
-        void onMapReceived();
-
     private:
         QVariantMap m_map;
-        QDBusInterface* m_interface;
 };
 
 #endif //FLIGHTRESERVATION_H

--- a/reservations/flightreservation/CMakeLists.txt
+++ b/reservations/flightreservation/CMakeLists.txt
@@ -6,7 +6,7 @@ set(dbus_SRCS org.kde.kdenow.flight.xml)
 
 qt5_generate_dbus_interface(flightreservation.h
                             org.kde.kdenow.flight.xml
-                            OPTIONS -M
+                            OPTIONS -M -s
                             )
 
 qt5_add_dbus_adaptor(dbus_SRCS

--- a/reservations/flightreservation/flightreservation.cpp
+++ b/reservations/flightreservation/flightreservation.cpp
@@ -157,7 +157,6 @@ void FlightReservation::setDBusData()
     m_dbusMap.insert("arrivalAirportCode", m_arrivalAirportCode);
     m_dbusMap.insert("arrivalTime", m_arrivalTime.toString());
 
-    emit addFlightCard();
     emit update();
 }
 

--- a/reservations/flightreservation/flightreservation.cpp
+++ b/reservations/flightreservation/flightreservation.cpp
@@ -156,6 +156,8 @@ void FlightReservation::setDBusData()
     m_dbusMap.insert("arrivalAirportName", m_arrivalAirportName);
     m_dbusMap.insert("arrivalAirportCode", m_arrivalAirportCode);
     m_dbusMap.insert("arrivalTime", m_arrivalTime.toString());
+
+    emit update();
 }
 
 QVariantMap FlightReservation::getMap()

--- a/reservations/flightreservation/flightreservation.cpp
+++ b/reservations/flightreservation/flightreservation.cpp
@@ -157,6 +157,7 @@ void FlightReservation::setDBusData()
     m_dbusMap.insert("arrivalAirportCode", m_arrivalAirportCode);
     m_dbusMap.insert("arrivalTime", m_arrivalTime.toString());
 
+    emit addFlightCard();
     emit update();
 }
 

--- a/reservations/flightreservation/flightreservation.h
+++ b/reservations/flightreservation/flightreservation.h
@@ -41,6 +41,7 @@ class FlightReservation : public AbstractReservationPlugin
     Q_SIGNALS:
         void extractedData();
         void addedToDatabase();
+        Q_SCRIPTABLE void update();
 
     public Q_SLOTS:
         QVariantMap getMap();

--- a/reservations/flightreservation/flightreservation.h
+++ b/reservations/flightreservation/flightreservation.h
@@ -42,7 +42,6 @@ class FlightReservation : public AbstractReservationPlugin
         void extractedData();
         void addedToDatabase();
         Q_SCRIPTABLE void update();
-        Q_SCRIPTABLE addFlightCard();
 
     public Q_SLOTS:
         QVariantMap getMap();

--- a/reservations/flightreservation/flightreservation.h
+++ b/reservations/flightreservation/flightreservation.h
@@ -42,6 +42,7 @@ class FlightReservation : public AbstractReservationPlugin
         void extractedData();
         void addedToDatabase();
         Q_SCRIPTABLE void update();
+        Q_SCRIPTABLE addFlightCard();
 
     public Q_SLOTS:
         QVariantMap getMap();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(dbus_SRCS org.kde.kdenow.xml)
 
 qt5_generate_dbus_interface(daemon.h
                             org.kde.kdenow.xml
+                            OPTIONS -M
                             )
 
 qt5_add_dbus_adaptor(dbus_SRCS

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -265,3 +265,10 @@ void Daemon::onIdleChanged(KIMAP::IdleJob* job, const QString& mailBox,
         emit signalUpdateProcess();
     }
 }
+
+QString Daemon::startDaemon()
+{
+    QString ret;
+    ret = "Started Daemon...";
+    return ret;
+}

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -56,6 +56,9 @@ class KDENOWCORE_EXPORT Daemon : public QObject
         void fetchedEmail(KIMAP::MessagePtr message);
         void signalUpdateProcess();
 
+    public Q_SLOTS:
+        QString startDaemon();
+
     private Q_SLOTS:
         void onLoginJobFinished(KJob* job);
         void onSelectJobFinished(KJob* job);


### PR DESCRIPTION
The way this works is that, when we have data, a signal is emitted over
D-Bus by Plugin. On receiving this signal, the plasmoid's lib calls the
relevant method in Plugin over D-Bus

Builds fine. Tested with a small test app, which can be found on,
https://github.com/g33kyaditya/rough/tree/master/dbus/get
