### PR TITLE
Avoid downloading redundant email and pass data as d-bus signal parameter

### DIFF
--- a/plugins/restaurantreservation/CMakeLists.txt
+++ b/plugins/restaurantreservation/CMakeLists.txt
@@ -6,7 +6,7 @@ set(dbus_SRCS org.kde.kdenow.restaurant.xml)
 
 qt5_generate_dbus_interface(restaurantreservation.h
                             org.kde.kdenow.restaurant.xml
-                            OPTIONS -s
+                            OPTIONS -m -s
                             )
 
 qt5_add_dbus_adaptor(dbus_SRCS

--- a/plugins/restaurantreservation/CMakeLists.txt
+++ b/plugins/restaurantreservation/CMakeLists.txt
@@ -6,7 +6,7 @@ set(dbus_SRCS org.kde.kdenow.restaurant.xml)
 
 qt5_generate_dbus_interface(restaurantreservation.h
                             org.kde.kdenow.restaurant.xml
-                            OPTIONS -M -s
+                            OPTIONS -M -S
                             )
 
 qt5_add_dbus_adaptor(dbus_SRCS

--- a/plugins/restaurantreservation/CMakeLists.txt
+++ b/plugins/restaurantreservation/CMakeLists.txt
@@ -6,7 +6,7 @@ set(dbus_SRCS org.kde.kdenow.restaurant.xml)
 
 qt5_generate_dbus_interface(restaurantreservation.h
                             org.kde.kdenow.restaurant.xml
-                            OPTIONS -M -S
+                            OPTIONS -s
                             )
 
 qt5_add_dbus_adaptor(dbus_SRCS

--- a/plugins/restaurantreservation/restaurantreservation.cpp
+++ b/plugins/restaurantreservation/restaurantreservation.cpp
@@ -143,17 +143,30 @@ void RestaurantReservation::initDatabase()
 
 void RestaurantReservation::setDBusData()
 {
-    m_dbusData.insert("reservationNumber", m_reservationNumber);
-    m_dbusData.insert("name", m_name);
-    m_dbusData.insert("startDate", m_startDate);
-    m_dbusData.insert("startTime", m_startTime);
-    m_dbusData.insert("partySize", m_partySize);
-    m_dbusData.insert("restaurantName", m_restaurantName);
-    m_dbusData.insert("streetAddress", m_streetAddress);
-    m_dbusData.insert("addressLocality", m_addressLocality);
-    m_dbusData.insert("addressRegion", m_addressRegion);
+    QStringList keys, values;   // QTBUG-21577 : qdbusxml2cpp fails to parse QVariantMap parameter
+                                //               for D-Bus signal
 
-    emit update(m_dbusData);
+    keys.append("reservationNumber");
+    keys.append("name");
+    keys.append("startDate");
+    keys.append("startTime");
+    keys.append("partySize");
+    keys.append("restaurantName");
+    keys.append("streetAddress");
+    keys.append("addressLocality");
+    keys.append("addressRegion");
+
+    values.append(m_reservationNumber);
+    values.append(m_name);
+    values.append(m_startDate);
+    values.append(m_startTime);
+    values.append(QString::number(m_partySize));
+    values.append(m_restaurantName);
+    values.append(m_streetAddress);
+    values.append(m_addressLocality);
+    values.append(m_addressRegion);
+
+    emit update(keys, values);
 }
 
 void RestaurantReservation::getDataFromDatabase()

--- a/plugins/restaurantreservation/restaurantreservation.cpp
+++ b/plugins/restaurantreservation/restaurantreservation.cpp
@@ -44,6 +44,8 @@ RestaurantReservation::RestaurantReservation(QObject* parent, const QVariantList
     m_pluginName = "restaurantDataExtractor";
     connect(this, &RestaurantReservation::extractedData, this, &RestaurantReservation::cacheData);
     connect(this, &RestaurantReservation::extractedData, this, &RestaurantReservation::setDBusData);
+    initDatabase();
+    getDataFromDatabase();
 }
 
 RestaurantReservation::~RestaurantReservation()
@@ -61,7 +63,6 @@ void RestaurantReservation::start()
     foreach(QVariantMap map, m_maps) {
         if (map["@type"] == "FoodEstablishmentReservation") {
             extract(map);
-            break;
         }
     }
 }
@@ -73,8 +74,8 @@ void RestaurantReservation::extract(QVariantMap& map)
     QVariantMap reservationForMap = map["reservationFor"].toMap();
 
     QDateTime startDateTime = map["startTime"].toDateTime();
-    m_startDate = startDateTime.date();
-    m_startTime = startDateTime.time();
+    m_startDate = startDateTime.date().toString();
+    m_startTime = startDateTime.time().toString("h:mm AP");
     m_partySize = map["partySize"].toInt();
 
     QVariantMap addressMap = reservationForMap["address"].toMap();
@@ -97,8 +98,8 @@ void RestaurantReservation::cacheData()
     updateQuery.prepare(queryString);
     updateQuery.bindValue(":reservationNumber", m_reservationNumber);
     updateQuery.bindValue(":name", m_name);
-    updateQuery.bindValue(":startDate", m_startDate.toString());
-    updateQuery.bindValue(":startTime", m_startTime.toString("h:mm AP"));
+    updateQuery.bindValue(":startDate", m_startDate);
+    updateQuery.bindValue(":startTime", m_startTime);
     updateQuery.bindValue(":partySize", m_partySize);
     updateQuery.bindValue(":restaurantName", m_restaurantName);
     updateQuery.bindValue(":streetAddress", m_streetAddress);
@@ -144,20 +145,58 @@ void RestaurantReservation::setDBusData()
 {
     m_dbusData.insert("reservationNumber", m_reservationNumber);
     m_dbusData.insert("name", m_name);
-    m_dbusData.insert("startDate", m_startDate.toString());
-    m_dbusData.insert("startTime", m_startTime.toString("h:mm AP"));
+    m_dbusData.insert("startDate", m_startDate);
+    m_dbusData.insert("startTime", m_startTime);
     m_dbusData.insert("partySize", m_partySize);
     m_dbusData.insert("restaurantName", m_restaurantName);
     m_dbusData.insert("streetAddress", m_streetAddress);
     m_dbusData.insert("addressLocality", m_addressLocality);
     m_dbusData.insert("addressRegion", m_addressRegion);
 
-    emit update();
+    emit update(m_dbusData);
 }
 
-QVariantMap RestaurantReservation::getMap()
+void RestaurantReservation::getDataFromDatabase()
 {
-    return m_dbusData;
+    QSqlQuery dataQuery(m_db);
+    QString queryString = "select * from Restaurant";
+    dataQuery.prepare(queryString);
+
+    if (!dataQuery.exec()) {
+        qWarning() << "Unable to fetch existing records from database";
+        qWarning() << dataQuery.lastError();
+    }
+    else {
+        qDebug() << "Fetched Records from Table Restaurant Successfully";
+    }
+
+    QList< QVariantMap > listOfMapsInDatabase;
+    while(dataQuery.next()) {
+        QVariantMap map;
+        map.insert("reservationNumber", dataQuery.value(1).toString());
+        map.insert("name", dataQuery.value(2).toString());
+        map.insert("startDate", dataQuery.value(3).toString());
+        map.insert("startTime", dataQuery.value(4).toString());
+        map.insert("partySize", dataQuery.value(5).toInt());
+        map.insert("restaurantName", dataQuery.value(6).toString());
+        map.insert("streetAddress", dataQuery.value(7).toString());
+        map.insert("addressLocality", dataQuery.value(8).toString());
+        map.insert("addressRegion", dataQuery.value(9).toString());
+        listOfMapsInDatabase.append(map);
+    }
+    qDebug() << listOfMapsInDatabase << "\n";
+    foreach(QVariantMap map, listOfMapsInDatabase) {
+        m_reservationNumber = map["reservationNumber"].toString();
+        m_name = map["name"].toString();
+        m_startDate = map["startDate"].toString();
+        m_startTime = map["startTime"].toString();
+        m_partySize = map["partySize"].toInt();
+        m_restaurantName = map["restaurantName"].toString();
+        m_streetAddress = map["streetAddress"].toString();
+        m_addressLocality = map["addressLocality"].toString();
+        m_addressRegion = map["addressRegion"].toString();
+        setDBusData();
+    }
 }
 
 #include "restaurantreservation.moc"

--- a/plugins/restaurantreservation/restaurantreservation.h
+++ b/plugins/restaurantreservation/restaurantreservation.h
@@ -39,30 +39,24 @@ class RestaurantReservation : public AbstractReservationPlugin
         QString plugin() const;
         void extract(QVariantMap& map);
         void initDatabase();
-        void getDataFromDatabase();
+        void recordsInDatabase();
 
     Q_SIGNALS:
-        void extractedData();
+        void extractedData(QVariantMap& map);
         Q_SCRIPTABLE void update(QStringList keys, QStringList values);
+        Q_SCRIPTABLE void loadedRestaurantPlugin();
+
+    public Q_SLOTS:
+        Q_SCRIPTABLE void getDatabaseRecordsOverDBus();
 
     private Q_SLOTS:
-        void cacheData();
-        void setDBusData();
+        void cacheData(QVariantMap& map);
+        void sendDataOverDBus(QVariantMap& map);
 
     private:
         QString m_pluginName;
-
         QSqlDatabase m_db;
-
-        QString m_reservationNumber;
-        QString m_name;
-        QString m_startDate;
-        QString m_startTime;
-        int m_partySize;
-        QString m_restaurantName;
-        QString m_streetAddress;
-        QString m_addressLocality;
-        QString m_addressRegion;
+        QList < QVariantMap > m_listOfMapsInDatabase;
 };
 
 #endif //RESTAURANTRESERVATION_H

--- a/plugins/restaurantreservation/restaurantreservation.h
+++ b/plugins/restaurantreservation/restaurantreservation.h
@@ -24,6 +24,7 @@
 
 #include <QtCore/QDate>
 #include <QtCore/QTime>
+#include <QtCore/QStringList>
 #include <QtSql/QSqlDatabase>
 
 class RestaurantReservation : public AbstractReservationPlugin
@@ -42,10 +43,7 @@ class RestaurantReservation : public AbstractReservationPlugin
 
     Q_SIGNALS:
         void extractedData();
-        void update();
-
-    public Q_SLOTS:
-        QVariantMap getMap();
+        Q_SCRIPTABLE void update(QStringList keys, QStringList values);
 
     private Q_SLOTS:
         void cacheData();
@@ -65,8 +63,6 @@ class RestaurantReservation : public AbstractReservationPlugin
         QString m_streetAddress;
         QString m_addressLocality;
         QString m_addressRegion;
-
-        QVariantMap m_dbusData;
 };
 
 #endif //RESTAURANTRESERVATION_H

--- a/plugins/restaurantreservation/restaurantreservation.h
+++ b/plugins/restaurantreservation/restaurantreservation.h
@@ -38,13 +38,11 @@ class RestaurantReservation : public AbstractReservationPlugin
         QString plugin() const;
         void extract(QVariantMap& map);
         void initDatabase();
+        void getDataFromDatabase();
 
     Q_SIGNALS:
         void extractedData();
-        Q_SCRIPTABLE void update();
-
-    public Q_SLOTS:
-        QVariantMap getMap();
+        void update(QVariantMap map);
 
     private Q_SLOTS:
         void cacheData();
@@ -57,8 +55,8 @@ class RestaurantReservation : public AbstractReservationPlugin
 
         QString m_reservationNumber;
         QString m_name;
-        QDate m_startDate;
-        QTime m_startTime;
+        QString m_startDate;
+        QString m_startTime;
         int m_partySize;
         QString m_restaurantName;
         QString m_streetAddress;

--- a/qml/datahandler.cpp
+++ b/qml/datahandler.cpp
@@ -83,20 +83,17 @@ void DataHandler::onHotelMapReceived()
     emit hotelDataReceived();
 }
 
-void DataHandler::onRestaurantMapReceived()
+void DataHandler::onRestaurantMapReceived(QStringList keys, QStringList values)
 {
-    QDBusInterface* interface = new QDBusInterface("org.kde.kdenow", "/Restaurant");
-    QDBusReply<QVariantMap> reply = interface->call("getMap");
-    if (reply.isValid()) {
-        qDebug() << "Valid Reply received from org.kde.kdenow /Restaurant getMap";
-        qDebug() << reply.value();
-    }
-    else {
-        qDebug() << "Did not receive a valid reply from org.kde.kdenow /Restaurant getMap";
-        return;
-    }
 
-    m_map = reply.value();
+    QStringList::iterator keysIter = keys.begin();
+    QStringList::iterator valuesIter = values.begin();
+    while (keysIter != keys.end()) {
+        m_map.insert((*keysIter), (*valuesIter));
+        keysIter++;
+        valuesIter++;
+    }
+    qDebug() << m_map << "\n";
     emit restaurantDataReceived();
 }
 
@@ -161,7 +158,7 @@ void DataHandler::setDBusConnections()
     dbus.connect("org.kde.kdenow", "/Hotel", "org.kde.kdenow.hotel",
                  "update", this, SLOT(onHotelMapReceived()));
     dbus.connect("org.kde.kdenow", "/Restaurant", "org.kde.kdenow.restaurant",
-                 "update", this, SLOT(onRestaurantMapReceived()));
+                 "update", this, SLOT(onRestaurantMapReceived(QStringList, QStringList)));
 }
 
 void DataHandler::checkWallet()

--- a/qml/datahandler.h
+++ b/qml/datahandler.h
@@ -45,7 +45,7 @@ class DataHandler : public QObject
         void onEventMapReceived();
         void onFlightMapReceived();
         void onHotelMapReceived();
-        void onRestaurantMapReceived();
+        void onRestaurantMapReceived(QStringList keys, QStringList values);
         void onCredentialsInput(QString, QString, QString, QString);
         Q_INVOKABLE QVariantMap getMap();
         void setDBusConnections();

--- a/qml/datahandler.h
+++ b/qml/datahandler.h
@@ -48,7 +48,8 @@ class DataHandler : public QObject
         void onRestaurantMapReceived(QStringList keys, QStringList values);
         void onCredentialsInput(QString, QString, QString, QString);
         Q_INVOKABLE QVariantMap getMap();
-        void setDBusConnections();
+        void startDaemon();
+        void onLoadedRestaurantPlugin();
 
     private:
         QVariantMap m_map;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(dbus_SRCS org.kde.kdenow.xml)
 
 qt5_generate_dbus_interface(daemon.h
                             org.kde.kdenow.xml
-                            OPTIONS -M
+                            OPTIONS -m
                             )
 
 qt5_add_dbus_adaptor(dbus_SRCS

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -31,6 +31,9 @@ Daemon::Daemon(QObject* parent): QObject(parent)
     QDBusConnection dbus = QDBusConnection::sessionBus();
     dbus.registerObject("/KDENow", this);
     dbus.registerService("org.kde.kdenow");
+    Processor * processor = SingletonFactory::instanceFor< Processor >();
+    connect(this, &Daemon::fetchRecordsFromDatabase, processor, &Processor::loadPlugins);
+    emit fetchRecordsFromDatabase();
 }
 
 void Daemon::setCredentials(QList < UserCredentials >& credentialsList) {
@@ -47,7 +50,6 @@ void Daemon::startEmailManagers()
     foreach(EmailManager* manager, m_emailManagersList) {
         Processor* processor = SingletonFactory::instanceFor< Processor >();
         connect(manager, &EmailManager::fetchedEmail, processor, &Processor::process);
-        connect(manager, &EmailManager::fetchEmailsFromDatabase, processor, &Processor::loadPlugins);
         manager->start();
     }
 }

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -32,8 +32,7 @@ Daemon::Daemon(QObject* parent): QObject(parent)
     dbus.registerObject("/KDENow", this);
     dbus.registerService("org.kde.kdenow");
     Processor * processor = SingletonFactory::instanceFor< Processor >();
-    connect(this, &Daemon::fetchRecordsFromDatabase, processor, &Processor::loadPlugins);
-    emit fetchRecordsFromDatabase();
+    processor->loadPlugins();
 }
 
 void Daemon::setCredentials(QList < UserCredentials >& credentialsList) {

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -47,6 +47,7 @@ void Daemon::startEmailManagers()
     foreach(EmailManager* manager, m_emailManagersList) {
         Processor* processor = SingletonFactory::instanceFor< Processor >();
         connect(manager, &EmailManager::fetchedEmail, processor, &Processor::process);
+        connect(manager, &EmailManager::fetchEmailsFromDatabase, processor, &Processor::loadPlugins);
         manager->start();
     }
 }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -36,9 +36,6 @@ class KDENOWCORE_EXPORT Daemon : public QObject
         Daemon(QObject* parent = 0);
         void startEmailManagers();
 
-    Q_SIGNALS:
-        void fetchRecordsFromDatabase();
-
     public Q_SLOTS:
         Q_SCRIPTABLE QString startDaemon();
         void setCredentials(QList < UserCredentials >& credentialsList);

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -36,8 +36,11 @@ class KDENOWCORE_EXPORT Daemon : public QObject
         Daemon(QObject* parent = 0);
         void startEmailManagers();
 
+    Q_SIGNALS:
+        void fetchRecordsFromDatabase();
+
     public Q_SLOTS:
-        QString startDaemon();
+        Q_SCRIPTABLE QString startDaemon();
         void setCredentials(QList < UserCredentials >& credentialsList);
 
     private:

--- a/src/emailmanager.cpp
+++ b/src/emailmanager.cpp
@@ -152,6 +152,11 @@ void EmailManager::searchNewMessages()
     group.writeEntry("MESSAGE_COUNT", QString::number(m_messageCount));
     group.config()->sync();
 
+    if (m_nextUid == uidNext) {
+        qDebug() << "Already downloaded top email\n";
+        emit fetchEmailsFromDatabase();
+        startIdle();
+    }
     KIMAP::ImapInterval interval(uidNext);
     KIMAP::ImapSet set;
     set.add(interval);

--- a/src/emailmanager.cpp
+++ b/src/emailmanager.cpp
@@ -19,6 +19,8 @@
 
 #include "emailmanager.h"
 #include "kdenowadaptor.h"
+#include "singletonfactory.h"
+#include "processor.h"
 
 #include <QtCore/QString>
 #include <QtDBus/QDBusConnection>
@@ -154,7 +156,6 @@ void EmailManager::searchNewMessages()
 
     if (m_nextUid == uidNext) {
         qDebug() << "Already downloaded top email\n";
-        emit fetchEmailsFromDatabase();
         startIdle();
     }
     KIMAP::ImapInterval interval(uidNext);

--- a/src/emailmanager.h
+++ b/src/emailmanager.h
@@ -50,7 +50,6 @@ class KDENOWCORE_EXPORT EmailManager : public QObject
     Q_SIGNALS:
         void fetchedEmail(KIMAP::MessagePtr message);
         void signalUpdateProcess();
-        void fetchEmailsFromDatabase();
 
     public Q_SLOTS:
         void start();

--- a/src/emailmanager.h
+++ b/src/emailmanager.h
@@ -50,6 +50,7 @@ class KDENOWCORE_EXPORT EmailManager : public QObject
     Q_SIGNALS:
         void fetchedEmail(KIMAP::MessagePtr message);
         void signalUpdateProcess();
+        void fetchEmailsFromDatabase();
 
     public Q_SLOTS:
         void start();

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -61,12 +61,21 @@ void Processor::process(KIMAP::MessagePtr messagePtr)
 void Processor::extractNeededData(QList < QVariantMap >& listOfMap)
 {
     if (!pluginsLoaded) {
-        PluginsLoader loader;
-        m_pluginList = loader.load();
-        pluginsLoaded = true;
+        loadPlugins();
     }
+
     foreach (AbstractReservationPlugin* plugin, m_pluginList) {
         plugin->setMap(listOfMap);
         plugin->start();
     }
 }
+
+void Processor::loadPlugins()
+{
+    if (!pluginsLoaded) {
+        PluginsLoader loader;
+        m_pluginList = loader.load();
+        pluginsLoaded = true;
+    }
+}
+

--- a/src/processor.h
+++ b/src/processor.h
@@ -33,14 +33,13 @@ class KDENOWCORE_EXPORT Processor : public QObject
 
     public:
         explicit Processor(QObject* parent = 0);
-        bool isAlreadyDownloaded();
+        void loadPlugins();
 
     public Q_SLOTS:
         void process(KIMAP::MessagePtr messagePtr);
 
     private:
         void extractNeededData(QList < QVariantMap >& listOfMap);
-        void extractFlightData();
 
         KIMAP::MessagePtr m_messagePtr;
         QList< AbstractReservationPlugin* > m_pluginList;

--- a/src/processor.h
+++ b/src/processor.h
@@ -33,10 +33,10 @@ class KDENOWCORE_EXPORT Processor : public QObject
 
     public:
         explicit Processor(QObject* parent = 0);
-        void loadPlugins();
 
     public Q_SLOTS:
         void process(KIMAP::MessagePtr messagePtr);
+        void loadPlugins();
 
     private:
         void extractNeededData(QList < QVariantMap >& listOfMap);

--- a/src/processor.h
+++ b/src/processor.h
@@ -33,10 +33,10 @@ class KDENOWCORE_EXPORT Processor : public QObject
 
     public:
         explicit Processor(QObject* parent = 0);
+        void loadPlugins();
 
     public Q_SLOTS:
         void process(KIMAP::MessagePtr messagePtr);
-        void loadPlugins();
 
     private:
         void extractNeededData(QList < QVariantMap >& listOfMap);


### PR DESCRIPTION
The last two different commits are of interest.

One in which we avoid downloading new email if it's not a new one.

In the other, we pass the restaurant plugin information in QStringLists over D-Bus signal
